### PR TITLE
[IMP] add addons_path config option

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,9 +7,7 @@ Changes
 
 1.0.5 (2018-10-26)
 ------------------
-- add --addons-path parameter as a very volatile config option
-
-
+- add --addons-path option for it's high volatility
 
 1.0.4 (2018-10-07)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,12 @@ Changes
 .. ----------
 .. - ...
 
+1.0.5 (2018-10-26)
+------------------
+- add --addons-path parameter as a very volatile config option
+
+
+
 1.0.4 (2018-10-07)
 ------------------
 - silence deprecation warning

--- a/README.rst
+++ b/README.rst
@@ -277,6 +277,10 @@ Author:
 
 - Stéphane Bidoul (`ACSONE <http://acsone.eu/>`_)
 
+Contributor:
+
+- David Arnold (`XOE <https://xoe.solutions>`_)
+
 Inspiration has been drawn from:
 
 - `anybox.recipe.odoo <https://github.com/anybox/anybox.recipe.odoo>`_

--- a/README.rst
+++ b/README.rst
@@ -149,18 +149,22 @@ Command line interface (click-odoo)
     to be a terminal.
 
   Options:
-    -c, --config PATH               Specify the Odoo configuration file. Other
+    -c, --config FILE               Specify the Odoo configuration file. Other
                                     ways to provide it are with the ODOO_RC or
                                     OPENERP_SERVER environment variables, or
                                     ~/.odoorc (Odoo >= 10) or
                                     ~/.openerp_serverrc.
+    --addons-path TEXT              Specify the addons path. If present, this
+                                    parameter takes precedence over the addons
+                                    path provided in the Odoo configuration
+                                    file.
     -d, --database TEXT             Specify the database name. If present, this
                                     parameter takes precedence over the database
                                     provided in the Odoo configuration file.
     --log-level TEXT                Specify the logging level. Accepted values
                                     depend on the Odoo version, and include
                                     debug, info, warn, error.  [default: info]
-    --logfile PATH                  Specify the log file.
+    --logfile FILE                  Specify the log file.
     --rollback                      Rollback the transaction even if the script
                                     does not raise an exception. Note that if
                                     the script itself commits, this option has

--- a/click_odoo/cli.py
+++ b/click_odoo/cli.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 # Copyright 2018 ACSONE SA/NV (<http://acsone.eu>)
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 
@@ -31,6 +32,10 @@ def env_options(default_log_level='info', with_rollback=True,
                            "OPENERP_SERVER environment variables, "
                            "or ~/.odoorc (Odoo >= 10) "
                            "or ~/.openerp_serverrc.")
+        @click.option('--addons-path', envvar=['ODOO_ADDONS_PATH'],
+                      help="Specify the addons path. If present, this "
+                           "parameter takes precedence over the addons path "
+                           "provided in the Odoo configuration file.")
         @click.option('--database', '-d', envvar=['PGDATABASE'],
                       help="Specify the database name. If present, this "
                            "parameter takes precedence over the database "
@@ -52,10 +57,10 @@ def env_options(default_log_level='info', with_rollback=True,
                            "is implied when an interactive console is "
                            "started.")
         @functools.wraps(func)
-        def wrapped(config, log_level, logfile, database=None, rollback=False,
-                    *args, **kwargs):
+        def wrapped(config, log_level, logfile, addons_path=None,
+                    database=None, rollback=False, *args, **kwargs):
             try:
-                parse_config(config, database, log_level, logfile)
+                parse_config(config, database, log_level, logfile, addons_path)
                 if not database:
                     database = odoo.tools.config['db_name']
                 if with_database and database_required and not database:

--- a/click_odoo/env.py
+++ b/click_odoo/env.py
@@ -31,7 +31,8 @@ def _fix_logging(series):
                     handler.stream = sys.stderr
 
 
-def parse_config(config=None, database=None, log_level=None, logfile=None):
+def parse_config(config=None, database=None, log_level=None, logfile=None,
+                 addons_path=None):
     series = odoo.release.version_info[0]
 
     odoo_args = []
@@ -47,6 +48,8 @@ def parse_config(config=None, database=None, log_level=None, logfile=None):
         odoo_args.extend(['--log-level', log_level])
     if logfile:
         odoo_args.extend(['--logfile', logfile])
+    if addons_path:
+        odoo_args.extend(['--addons-path', addons_path])
     # see https://github.com/odoo/odoo/commit/b122217f74
     odoo.tools.config['load_language'] = None
     odoo.tools.config.parse_config(odoo_args)

--- a/tests/data/addons/addon1/__openerp__.py
+++ b/tests/data/addons/addon1/__openerp__.py
@@ -1,0 +1,4 @@
+# must be __openerp__.py, for compatibility with 8, 9 tests
+{
+    'name': 'addon 1',
+}

--- a/tests/scripts/script5.py
+++ b/tests/scripts/script5.py
@@ -1,0 +1,10 @@
+# noqa
+try:
+    import odoo.release as release
+except (AttributeError, ImportError):
+    import openerp.release as release
+
+if release.version_info[0] > 9:
+    import odoo.addons.addon1  # noqa
+else:
+    import openerp.addons.addon1  # noqa

--- a/tests/test_click_odoo.py
+++ b/tests/test_click_odoo.py
@@ -235,6 +235,35 @@ def test_env_options_withdb(odoodb, tmpdir):
     assert "No database provided" in result.output
 
 
+def test_env_options_addons_path():
+    script = os.path.join(here, 'scripts', 'script5.py')
+    cmd = [
+        'click-odoo',
+        '--',
+        script
+    ]
+    try:
+        subprocess.check_output(cmd)
+        assert False
+    except subprocess.CalledProcessError as err:
+        assert err.returncode != 0
+
+    addons_path = ','.join([
+        os.path.join(odoo.__path__[0], 'addons'),
+        os.path.join(os.path.dirname(__file__), 'data', 'addons'),
+    ])
+
+    script = os.path.join(here, 'scripts', 'script5.py')
+    cmd = [
+        'click-odoo',
+        '--addons-path', addons_path,
+        '--',
+        script
+    ]
+    r = subprocess.check_call(cmd)
+    assert r == 0
+
+
 def test_env_options_nodb(odoodb, tmpdir):
     @click.command()
     @click_odoo.env_options(with_database=False)


### PR DESCRIPTION
addons_path is, after database, the most volatile configuration parameter
only known at runtime in many cases (contrary to other config file items).

Expose this configuration parameter appropriately.

**Note:** See how the addons folder is construed dynamically in [this use case](https://github.com/xoe-labs/dockery-odoo/blob/80cb0647ccff285c4450c9f4a8410e7bfc298ec5/images/base/v-11.0/out/entrypoint.d/10-set-appenv.sh#L18-L32).