### PR TITLE
Feat extend config machinery

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,8 +8,7 @@ Changes
 1.0.5 (2018-10-26)
 ------------------
 - add --addons-path parameter as a very volatile config option
-
-
+- include a config callback to manipulate config options pre-env
 
 1.0.4 (2018-10-07)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,12 @@ Changes
 .. ----------
 .. - ...
 
+1.0.5 (2018-10-26)
+------------------
+- add --addons-path parameter as a very volatile config option
+
+
+
 1.0.4 (2018-10-07)
 ------------------
 - silence deprecation warning

--- a/README.rst
+++ b/README.rst
@@ -149,18 +149,22 @@ Command line interface (click-odoo)
     to be a terminal.
 
   Options:
-    -c, --config PATH               Specify the Odoo configuration file. Other
+    -c, --config FILE               Specify the Odoo configuration file. Other
                                     ways to provide it are with the ODOO_RC or
                                     OPENERP_SERVER environment variables, or
                                     ~/.odoorc (Odoo >= 10) or
                                     ~/.openerp_serverrc.
+    --addons-path TEXT              Specify the addons path. If present, this
+                                    parameter takes precedence over the addons
+                                    path provided in the Odoo configuration
+                                    file.
     -d, --database TEXT             Specify the database name. If present, this
                                     parameter takes precedence over the database
                                     provided in the Odoo configuration file.
     --log-level TEXT                Specify the logging level. Accepted values
                                     depend on the Odoo version, and include
                                     debug, info, warn, error.  [default: info]
-    --logfile PATH                  Specify the log file.
+    --logfile FILE                  Specify the log file.
     --rollback                      Rollback the transaction even if the script
                                     does not raise an exception. Note that if
                                     the script itself commits, this option has

--- a/click_odoo/cli.py
+++ b/click_odoo/cli.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 # Copyright 2018 ACSONE SA/NV (<http://acsone.eu>)
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 
@@ -31,6 +32,10 @@ def env_options(default_log_level='info', with_rollback=True,
                            "OPENERP_SERVER environment variables, "
                            "or ~/.odoorc (Odoo >= 10) "
                            "or ~/.openerp_serverrc.")
+        @click.option('--addons-path', envvar=['ODOO_ADDONS_PATH'],
+                      help="Specify the addons path. If present, this "
+                           "parameter takes precedence over the addons path "
+                           "provided in the Odoo configuration file.")
         @click.option('--database', '-d', envvar=['PGDATABASE'],
                       help="Specify the database name. If present, this "
                            "parameter takes precedence over the database "
@@ -52,10 +57,10 @@ def env_options(default_log_level='info', with_rollback=True,
                            "is implied when an interactive console is "
                            "started.")
         @functools.wraps(func)
-        def wrapped(config, log_level, logfile, database=None, rollback=False,
-                    *args, **kwargs):
+        def wrapped(config, log_level, logfile, addons_path=None,
+                    database=None, rollback=False, *args, **kwargs):
             try:
-                parse_config(config, database, log_level, logfile)
+                parse_config(config, database, log_level, logfile, addons_path)
                 if not database:
                     database = odoo.tools.config['db_name']
                 if with_database and database_required and not database:

--- a/click_odoo/cli.py
+++ b/click_odoo/cli.py
@@ -23,7 +23,8 @@ def _remove_click_option(func, name):
 
 
 def env_options(default_log_level='info', with_rollback=True,
-                with_database=True, database_required=True):
+                with_database=True, database_required=True,
+                config_callback=None):
     def inner(func):
         @click.option('--config', '-c', envvar=['ODOO_RC', 'OPENERP_SERVER'],
                       type=click.Path(exists=True, dir_okay=False),
@@ -60,7 +61,10 @@ def env_options(default_log_level='info', with_rollback=True,
         def wrapped(config, log_level, logfile, addons_path=None,
                     database=None, rollback=False, *args, **kwargs):
             try:
-                parse_config(config, database, log_level, logfile, addons_path)
+                parse_config(
+                    config, database, log_level, logfile, addons_path,
+                    config_callback(*args, **kwargs)
+                    if callable(config_callback) else None)
                 if not database:
                     database = odoo.tools.config['db_name']
                 if with_database and database_required and not database:

--- a/click_odoo/env.py
+++ b/click_odoo/env.py
@@ -31,25 +31,35 @@ def _fix_logging(series):
                     handler.stream = sys.stderr
 
 
+def _get_config_args(**kwargs):
+    """ This method can be patched for custom downstream config API """
+    odoo_args = []
+    if kwargs.get('config'):
+        odoo_args.extend(['-c', kwargs.get('config')])
+    if kwargs.get('database'):
+        odoo_args.extend(['-d', kwargs.get('database')])
+    if kwargs.get('log_level'):
+        odoo_args.extend(['--log-level', kwargs.get('log_level')])
+    if kwargs.get('logfile'):
+        odoo_args.extend(['--logfile', kwargs.get('logfile')])
+    if kwargs.get('addons_path'):
+        odoo_args.extend(['--addons-path', kwargs.get('addons_path')])
+    return odoo_args
+
+
 def parse_config(config=None, database=None, log_level=None, logfile=None,
-                 addons_path=None):
+                 addons_path=None, additional_odoo_args=None):
     series = odoo.release.version_info[0]
 
-    odoo_args = []
     # reset db_name in case we come from a previous run
     # where database has been set, in the second run the is no database
     # (mostly for tests)
     odoo.tools.config['db_name'] = None
-    if config:
-        odoo_args.extend(['-c', config])
-    if database:
-        odoo_args.extend(['-d', database])
-    if log_level:
-        odoo_args.extend(['--log-level', log_level])
-    if logfile:
-        odoo_args.extend(['--logfile', logfile])
-    if addons_path:
-        odoo_args.extend(['--addons-path', addons_path])
+    odoo_args = _get_config_args(
+        config=config, database=database, log_level=log_level,
+        logfile=logfile, addons_path=addons_path)
+    if additional_odoo_args:
+        odoo_args.append(additional_odoo_args)
     # see https://github.com/odoo/odoo/commit/b122217f74
     odoo.tools.config['load_language'] = None
     odoo.tools.config.parse_config(odoo_args)

--- a/click_odoo/env.py
+++ b/click_odoo/env.py
@@ -31,7 +31,8 @@ def _fix_logging(series):
                     handler.stream = sys.stderr
 
 
-def parse_config(config=None, database=None, log_level=None, logfile=None):
+def parse_config(config=None, database=None, log_level=None, logfile=None,
+                 addons_path=None):
     series = odoo.release.version_info[0]
 
     odoo_args = []
@@ -47,6 +48,8 @@ def parse_config(config=None, database=None, log_level=None, logfile=None):
         odoo_args.extend(['--log-level', log_level])
     if logfile:
         odoo_args.extend(['--logfile', logfile])
+    if addons_path:
+        odoo_args.extend(['--addons-path', addons_path])
     # see https://github.com/odoo/odoo/commit/b122217f74
     odoo.tools.config['load_language'] = None
     odoo.tools.config.parse_config(odoo_args)

--- a/tests/data/addons/addon1/__openerp__.py
+++ b/tests/data/addons/addon1/__openerp__.py
@@ -1,0 +1,4 @@
+# must be __openerp__.py, for compatibility with 8, 9 tests
+{
+    'name': 'addon 1',
+}


### PR DESCRIPTION
This is in order to be able to patch the config constructor in custom downstream scripts.

I'd like to patch them to create an enhanced tester script. However, adding the `--test-enable` flag and similar by default is not at all warranted.