### PR TITLE
[IMP] add support for click-plugins

### DIFF
--- a/click_odoo/cli.py
+++ b/click_odoo/cli.py
@@ -8,6 +8,10 @@ import sys
 
 import click
 
+from pkg_resources import iter_entry_points
+from click_plugins import with_plugins
+
+from . import options
 from . import console
 from .env import OdooEnvironment, parse_config, odoo
 
@@ -24,36 +28,15 @@ def _remove_click_option(func, name):
 def env_options(default_log_level='info', with_rollback=True,
                 with_database=True, database_required=True):
     def inner(func):
-        @click.option('--config', '-c', envvar=['ODOO_RC', 'OPENERP_SERVER'],
-                      type=click.Path(exists=True, dir_okay=False),
-                      help="Specify the Odoo configuration file. Other "
-                           "ways to provide it are with the ODOO_RC or "
-                           "OPENERP_SERVER environment variables, "
-                           "or ~/.odoorc (Odoo >= 10) "
-                           "or ~/.openerp_serverrc.")
-        @click.option('--database', '-d', envvar=['PGDATABASE'],
-                      help="Specify the database name. If present, this "
-                           "parameter takes precedence over the database "
-                           "provided in the Odoo configuration file.")
-        @click.option('--log-level',
-                      default=default_log_level,
-                      show_default=True,
-                      help="Specify the logging level. Accepted values depend "
-                           "on the Odoo version, and include debug, info, "
-                           "warn, error.")
-        @click.option('--logfile',
-                      type=click.Path(dir_okay=False),
-                      help="Specify the log file.")
-        @click.option('--rollback', is_flag=True,
-                      help="Rollback the transaction even if the script "
-                           "does not raise an exception. Note that if the "
-                           "script itself commits, this option has no effect. "
-                           "This is why it is not named dry run. This option "
-                           "is implied when an interactive console is "
-                           "started.")
+        @click.pass_context
+        @options.config_opt
+        @options.db_opt
+        @options.log_level_opt(default_log_level)
+        @options.logfile_opt
+        @options.rollback_opt
         @functools.wraps(func)
-        def wrapped(config, log_level, logfile, database=None, rollback=False,
-                    *args, **kwargs):
+        def wrapped(ctx, config, log_level, logfile, database=None,
+                    rollback=False, *args, **kwargs):
             try:
                 parse_config(config, database, log_level, logfile)
                 if not database:
@@ -68,10 +51,10 @@ def env_options(default_log_level='info', with_rollback=True,
                         database=database,
                         rollback=rollback,
                     ) as env:
-                        return func(env, *args, **kwargs)
+                        return func(ctx, env, *args, **kwargs)
                 else:
                     with odoo.api.Environment.manage():
-                        return func(None, *args, **kwargs)
+                        return func(ctx, None, *args, **kwargs)
             except Exception as e:
                 _logger.error("exception", exc_info=True)
                 raise click.ClickException(str(e))
@@ -83,37 +66,34 @@ def env_options(default_log_level='info', with_rollback=True,
     return inner
 
 
-@click.command(help="Execute a python script in an initialized Odoo "
-                    "environment. The script has access to a 'env' global "
-                    "variable which is an odoo.api.Environment "
-                    "initialized for the given database. If no script is "
-                    "provided, the script is read from stdin or an "
-                    "interactive console is started if stdin appears "
-                    "to be a terminal.")
+@click.group(invoke_without_command=True)
 @env_options(database_required=False)
-@click.option('--interactive/--no-interactive', '-i',
-              help="Inspect interactively after running the script.")
-@click.option('--shell-interface',
-              help="Preferred shell interface for interactive mode. Accepted "
-                   "values are ipython, ptpython, bpython, python. If not "
-                   "provided they are tried in this order.")
-@click.argument('script', required=False,
-                type=click.Path(exists=True, dir_okay=False))
-@click.argument('script-args', nargs=-1)
-def main(env, interactive, shell_interface, script, script_args):
-    global_vars = {'env': env}
-    if script:
-        sys.argv[1:] = script_args
-        global_vars = runpy.run_path(
-            script, init_globals=global_vars, run_name='__main__')
-    if not script or interactive:
-        if console._isatty(sys.stdin):
-            if not env:
-                _logger.info("No environment set, use `-d dbname` to get one.")
-            console.Shell.interact(global_vars, shell_interface)
-            if env:
-                env.cr.rollback()
-        else:
-            sys.argv[:] = ['']
-            global_vars['__name__'] = '__main__'
-            exec(sys.stdin.read(), global_vars)
+@options.interactive_opt
+@options.shell_interface_opt
+@options.script_arg
+@options.script_args_arg
+@with_plugins(iter_entry_points('click_odoo.plugins'))
+def main(ctx, env, interactive, shell_interface, script, script_args):
+    """Execute a python script in an initialized Odoo environment. The script
+    has access to a 'env' global variable which is an odoo.api.Environment
+    initialized for the given database. If no script is provided, the script is
+    read from stdin or an interactive console is started if stdin appears to be
+    a terminal."""
+    if ctx.invoked_subcommand is None:
+        global_vars = {'env': env}
+        if script:
+            sys.argv[1:] = script_args
+            global_vars = runpy.run_path(
+                script, init_globals=global_vars, run_name='__main__')
+        if not script or interactive:
+            if console._isatty(sys.stdin):
+                if not env:
+                    _logger.info(
+                        "No environment set, use `-d dbname` to get one.")
+                console.Shell.interact(global_vars, shell_interface)
+                if env:
+                    env.cr.rollback()
+            else:
+                sys.argv[:] = ['']
+                global_vars['__name__'] = '__main__'
+                exec(sys.stdin.read(), global_vars)

--- a/click_odoo/options.py
+++ b/click_odoo/options.py
@@ -1,0 +1,63 @@
+# Copyright 2018 ACSONE SA/NV (<http://acsone.eu>)
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
+import click
+
+
+# Wrapper options
+config_opt = click.option(
+    '--config', '-c', envvar=['ODOO_RC', 'OPENERP_SERVER'],
+    type=click.Path(exists=True, dir_okay=False),
+    help="Specify the Odoo configuration file. Other "
+         "ways to provide it are with the ODOO_RC or "
+         "OPENERP_SERVER environment variables, "
+         "or ~/.odoorc (Odoo >= 10) "
+         "or ~/.openerp_serverrc."
+)
+
+db_opt = click.option(
+    '--database', '-d', envvar=['PGDATABASE'],
+    help="Specify the database name. If present, this "
+         "parameter takes precedence over the database "
+         "provided in the Odoo configuration file."
+)
+
+log_level_opt = lambda default_log_level: click.option(
+    '--log-level', default=default_log_level, show_default=True,
+    help="Specify the logging level. Accepted values depend "
+         "on the Odoo version, and include debug, info, "
+          "warn, error."
+)
+
+logfile_opt = click.option(
+    '--logfile', type=click.Path(dir_okay=False),
+    help="Specify the log file."
+)
+
+rollback_opt = click.option(
+    '--rollback', is_flag=True,
+    help="Rollback the transaction even if the script "
+         "does not raise an exception. Note that if the "
+         "script itself commits, this option has no effect. "
+         "This is why it is not named dry run. This option "
+         "is implied when an interactive console is "
+         "started."
+)
+
+# Main options
+interactive_opt = click.option(
+    '--interactive/--no-interactive', '-i',
+    help="Inspect interactively after running the script."
+)
+
+shell_interface_opt = click.option(
+    '--shell-interface',
+    help="Preferred shell interface for interactive mode. Accepted "
+         "values are ipython, ptpython, bpython, python. If not "
+         "provided they are tried in this order."
+)
+
+script_arg = click.argument(
+    'script', required=False, type=click.Path(exists=True, dir_okay=False)
+)
+
+script_args_arg = click.argument('script-args', nargs=-1)

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
     ],
     install_requires=[
         'click',
+        'click-plugins'
     ],
     license='LGPLv3+',
     author='ACSONE SA/NV',


### PR DESCRIPTION
The implementation of click-plugins makes passing the context mandatory (highly
recommended).

This makes it backwards incompatible as all function calls must recieve the
context as first argument.

Towards: https://github.com/acsone/click-odoo/issues/7

For discussion...