### PR TITLE
[REF] use a config object (extendable)

### DIFF
--- a/click_odoo/cli.py
+++ b/click_odoo/cli.py
@@ -10,7 +10,7 @@ import sys
 import click
 
 from . import console
-from .env import OdooEnvironment, odoo, parse_config
+from .env import OdooEnvironment, OdooConfig, odoo
 
 _logger = logging.getLogger(__name__)
 
@@ -89,7 +89,9 @@ def env_options(
             **kwargs
         ):
             try:
-                parse_config(config, database, log_level, logfile, addons_path)
+                OdooConfig(
+                    config, database, log_level, logfile, addons_path,
+                    *args, **kwargs).seed()
                 if not database:
                     database = odoo.tools.config["db_name"]
                 if with_database and database_required and not database:

--- a/click_odoo/cli.py
+++ b/click_odoo/cli.py
@@ -29,6 +29,7 @@ def env_options(
     with_database=True,
     database_required=True,
     environment_manager=OdooEnvironment,
+    config_preprocessor=OdooConfig,
 ):
     def inner(func):
         @click.option(
@@ -90,7 +91,7 @@ def env_options(
             **kwargs
         ):
             try:
-                OdooConfig(
+                config_preprocessor(
                     config, database, log_level, logfile, addons_path,
                     *args, **kwargs).seed()
                 if not database:

--- a/click_odoo/cli.py
+++ b/click_odoo/cli.py
@@ -10,7 +10,8 @@ import sys
 import click
 
 from . import console
-from .env import OdooEnvironment, OdooConfig, odoo
+from .env import OdooEnvironment, odoo
+from .config import OdooConfig
 
 _logger = logging.getLogger(__name__)
 

--- a/click_odoo/config.py
+++ b/click_odoo/config.py
@@ -1,0 +1,46 @@
+# Copyright 2018 ACSONE SA/NV (<http://acsone.eu>)
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
+
+from .env import odoo, fix_logging
+
+
+class OdooConfig(object):
+    """ Construct class for odoo command line args """
+
+    def __init__(self, config=None, database=None,
+                 log_level=None, logfile=None, addons_path=None,
+                 *args, **kwargs):
+        self.config = config
+        self.database = database
+        self.log_level = log_level
+        self.logfile = logfile
+        self.addons_path = addons_path
+        self.args = args
+        self.kwargs = kwargs
+
+    def _parse(self):
+        odoo_args = []
+        if self.config:
+            odoo_args.extend(['-c', self.config])
+        if self.database:
+            odoo_args.extend(['-d', self.database])
+        if self.log_level:
+            odoo_args.extend(['--log-level', self.log_level])
+        if self.logfile:
+            odoo_args.extend(['--logfile', self.logfile])
+        if self.addons_path:
+            odoo_args.extend(["--addons-path", self.addons_path])
+        return odoo_args
+
+    def seed(self):
+        """ Seed the odoo config object """
+
+        # reset db_name in case we come from a previous run
+        # where database has been set, in the second run the is no database
+        # (mostly for tests)
+        odoo.tools.config['db_name'] = None
+        # see https://github.com/odoo/odoo/commit/b122217f74
+        odoo.tools.config['load_language'] = None
+        odoo.tools.config.parse_config(self._parse())
+        fix_logging()
+        odoo.cli.server.report_configuration()

--- a/click_odoo/env.py
+++ b/click_odoo/env.py
@@ -23,56 +23,14 @@ except ImportError:
 _logger = logging.getLogger(__name__)
 
 
-def _fix_logging(series):
-    if series < 9:
+def fix_logging():
+    if odoo.release.version_info[0] < 9:
         handlers = logging.getLogger().handlers
         if handlers and len(handlers) == 1:
             handler = handlers[0]
             if isinstance(handler, logging.StreamHandler):
                 if handler.stream is sys.stdout:
                     handler.stream = sys.stderr
-
-
-class OdooConfig(object):
-    """ Construct class for odoo command line args """
-
-    def __init__(self, config=None, database=None,
-                 log_level=None, logfile=None, addons_path=None,
-                 *args, **kwargs):
-        self.config = config
-        self.database = database
-        self.log_level = log_level
-        self.logfile = logfile
-        self.addons_path = addons_path
-        self.args = args
-        self.kwargs = kwargs
-
-    def _parse(self):
-        odoo_args = []
-        if self.config:
-            odoo_args.extend(['-c', self.config])
-        if self.database:
-            odoo_args.extend(['-d', self.database])
-        if self.log_level:
-            odoo_args.extend(['--log-level', self.log_level])
-        if self.logfile:
-            odoo_args.extend(['--logfile', self.logfile])
-        if self.addons_path:
-            odoo_args.extend(["--addons-path", self.addons_path])
-        return odoo_args
-
-    def seed(self):
-        """ Seed the odoo config object """
-        series = odoo.release.version_info[0]
-        # reset db_name in case we come from a previous run
-        # where database has been set, in the second run the is no database
-        # (mostly for tests)
-        odoo.tools.config['db_name'] = None
-        # see https://github.com/odoo/odoo/commit/b122217f74
-        odoo.tools.config['load_language'] = None
-        odoo.tools.config.parse_config(self._parse())
-        _fix_logging(series)
-        odoo.cli.server.report_configuration()
 
 
 @contextmanager

--- a/click_odoo/env.py
+++ b/click_odoo/env.py
@@ -33,31 +33,46 @@ def _fix_logging(series):
                     handler.stream = sys.stderr
 
 
-def parse_config(
-    config=None, database=None, log_level=None, logfile=None, addons_path=None
-):
-    series = odoo.release.version_info[0]
+class OdooConfig(object):
+    """ Construct class for odoo command line args """
 
-    odoo_args = []
-    # reset db_name in case we come from a previous run
-    # where database has been set, in the second run the is no database
-    # (mostly for tests)
-    odoo.tools.config["db_name"] = None
-    if config:
-        odoo_args.extend(["-c", config])
-    if database:
-        odoo_args.extend(["-d", database])
-    if log_level:
-        odoo_args.extend(["--log-level", log_level])
-    if logfile:
-        odoo_args.extend(["--logfile", logfile])
-    if addons_path:
-        odoo_args.extend(["--addons-path", addons_path])
-    # see https://github.com/odoo/odoo/commit/b122217f74
-    odoo.tools.config["load_language"] = None
-    odoo.tools.config.parse_config(odoo_args)
-    _fix_logging(series)
-    odoo.cli.server.report_configuration()
+    def __init__(self, config=None, database=None,
+                 log_level=None, logfile=None, addons_path=None,
+                 *args, **kwargs):
+        self.config = config
+        self.database = database
+        self.log_level = log_level
+        self.logfile = logfile
+        self.addons_path = addons_path
+        self.args = args
+        self.kwargs = kwargs
+
+    def _parse(self):
+        odoo_args = []
+        if self.config:
+            odoo_args.extend(['-c', self.config])
+        if self.database:
+            odoo_args.extend(['-d', self.database])
+        if self.log_level:
+            odoo_args.extend(['--log-level', self.log_level])
+        if self.logfile:
+            odoo_args.extend(['--logfile', self.logfile])
+        if self.addons_path:
+            odoo_args.extend(["--addons-path", self.addons_path])
+        return odoo_args
+
+    def seed(self):
+        """ Seed the odoo config object """
+        series = odoo.release.version_info[0]
+        # reset db_name in case we come from a previous run
+        # where database has been set, in the second run the is no database
+        # (mostly for tests)
+        odoo.tools.config['db_name'] = None
+        # see https://github.com/odoo/odoo/commit/b122217f74
+        odoo.tools.config['load_language'] = None
+        odoo.tools.config.parse_config(self._parse())
+        _fix_logging(series)
+        odoo.cli.server.report_configuration()
 
 
 @contextmanager


### PR DESCRIPTION
Refactor towards a config object and pass positional and named argument in order to be able to selectively extend the command line options in downstream `click-odoo` scripts.