### PR TITLE
2.0.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,12 @@ Changes
   on ``click.Command()``
 - replace ``@env_options`` wrapper with custom Command class
 
+1.1.1 (2018-11-01)
+------------------
+- add ``with_addons_path`` option to ``@click_odoo.env_options``
+  to control the presence of the ``--addons-path`` option. Defaults to False.
+  Enabled for the ``click-odoo`` CLI.
+
 1.1.0 (2018-10-31)
 ------------------
 - add ``environment_manager`` to ``@click_odoo.env_options``, providing

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,13 @@ Changes
 .. ----------
 .. - ...
 
+2.0.0 (2018-10-31)
+------------------
+- refactor to click native facilities, where possible
+- replace ``@env_options()`` named parameters with ``context_settings``
+  on ``click.Command()``
+- replace ``@env_options`` wrapper with custom Command class
+
 1.1.0 (2018-10-31)
 ------------------
 - add ``environment_manager`` to ``@click_odoo.env_options``, providing

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,8 @@ Changes
 - replace ``@env_options()`` named parameters with ``context_settings``
   on ``click.Command()``
 - replace ``@env_options`` wrapper with custom Command class
+- add ``default_overrides`` command key to manage script-scoped parameter
+  defaults (eg. adjust default for ``log_level`` or ``rollback``)
 
 1.1.1 (2018-11-01)
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -247,14 +247,17 @@ environment_manager
     environment_manager(database, rollback, **kwargs)
 
 
-``context_settings``
+``default_overrides``
 --------------------
 
-Additionally, you can use the standard click override mechanism to provide
-defaults for command flags via the ``context_settings`` keyword argument:
+Override defaults for command flags via the ``default_overrides`` keyword
+argument:
 
 log_level
   The default value for the ``--log-level`` option (default: 'info').
+
+rollback
+  The default value for the ``--rollback`` option (default: False).
 
 click_odoo.odoo namespace
 -------------------------

--- a/README.rst
+++ b/README.rst
@@ -224,6 +224,9 @@ with_database
   is not set (env is None). If ``with_database`` is False,
   ``database_required`` is implied to be False too.
 
+with_addons_path
+  Controls the presence of the ``--addons-path`` option (default: False).
+
 database_required
   Controls if a database must be provided through the ``--database``
   option or the Odoo configuration file (default: True).

--- a/README.rst
+++ b/README.rst
@@ -55,8 +55,9 @@ the following script named ``list-users2.py``.
   import click_odoo
 
 
-  @click.command()
-  @click_odoo.env_options(default_log_level='error')
+  @click.command(
+    cls=click_odoo.CommandWithOdooEnv,
+    context_settings={'log_level':'error'})
   @click.option('--say-hello', is_flag=True)
   def main(env, say_hello):
       if say_hello:
@@ -200,18 +201,16 @@ in the script.
 API
 ~~~
 
-click_odoo.env_options decorator
---------------------------------
+``env_options``
+---------------
 
-``@click_odoo.env_options()`` is a decorator that is used very much like
-``@click.option()`` and inserts the list of predefined ``click-odoo``
-options. Instead of passing down these options to the command, it prepares
-an odoo ``Environment`` and passes it as a ``env`` parameter.
+Customize the behaviour of ``click_odoo.CommandWithOdooEnv`` through
+``click.Command(env_options={})``.
 
-It is configurable with the following keyword arguments:
+``click_odoo.CommandWithOdooEnv`` prepares an odoo ``Environment`` and passes
+it as a ``env`` parameter.
 
-default_log_level
-  The default value for the ``-log-level`` option (default: 'info').
+It is configurable with the following keyword arguments in ``env_options``:
 
 with_rollback
   Controls the presence of the ``--rollback`` option (default: True).
@@ -238,9 +237,21 @@ environment_manager
   ``odoo.api.Environment``.
   It is invoked after Odoo configuration parsing and initialization.
   It must have the following signature (identical to ``OdooEnvironment``
-  below, plus ``**kwargs``)::
+  below, plus ``**kwargs``)
+
+  .. code-block:: python
 
     environment_manager(database, rollback, **kwargs)
+
+
+``context_settings``
+--------------------
+
+Additionally, you can use the standard click override mechanism to provide
+defaults for command flags via the ``context_settings`` keyword argument:
+
+log_level
+  The default value for the ``--log-level`` option (default: 'info').
 
 click_odoo.odoo namespace
 -------------------------

--- a/click_odoo/__init__.py
+++ b/click_odoo/__init__.py
@@ -1,7 +1,7 @@
 # Copyright 2018 ACSONE SA/NV (<http://acsone.eu>)
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 
-from .cli import env_options  # noqa
+from .cli import CommandWithOdooEnv  # noqa
 from .env import OdooEnvironment  # noqa
 from .env import odoo  # noqa
 from .env import odoo_bin  # noqa

--- a/click_odoo/cli.py
+++ b/click_odoo/cli.py
@@ -56,34 +56,43 @@ class CommandWithOdooEnv(click.Command):
         self.params.extend(self.env_params)  # So they appear in --help
 
     def _parse_env_args(self, ctx):
+        def _get(flag):
+            result = ctx.params.get(flag) or self.config_settings.get(flag)
+            if flag in ctx.params:
+                del ctx.params[flag]
+            if flag in self.config_settings:
+                del self.config_settings[flag]
+            return result
+
         odoo_args = []
         # reset db_name in case we come from a previous run
         # where database has been set, in the second run the is no database
         # (mostly for tests)
         odoo.tools.config["db_name"] = None
+
+        # fmt: off
         # Always present params
-        if ctx.params.get("config"):
-            odoo_args.extend(["-c", ctx.params["config"]])
-        del ctx.params["config"]
-        if ctx.params.get("log_level"):
-            odoo_args.extend(["--log-level", ctx.params["log_level"]])
-        del ctx.params["log_level"]
-        if ctx.params.get("logfile"):
-            odoo_args.extend(["--logfile", ctx.params["logfile"]])
-        del ctx.params["logfile"]
+        config      = _get("config")       # noqa
+        log_level   = _get("log_level")    # noqa
+        logfile     = _get("logfile")      # noqa
         # Conditionally present params
-        if ctx.params.get("addons_path"):
-            odoo_args.extend(["--addons-path", ctx.params["addons_path"]])
-        if "addons_path" in ctx.params:
-            del ctx.params["addons_path"]
-        if ctx.params.get("database"):
-            odoo_args.extend(["-d", ctx.params["database"]])
-        if "database" in ctx.params:
-            del ctx.params["database"]
-        if ctx.params.get("rollback"):
-            self.rollback = ctx.params["rollback"]
-        if "rollback" in ctx.params:
-            del ctx.params["rollback"]
+        addons_path = _get("addons_path")  # noqa
+        database    = _get("database")     # noqa
+        rollback    = _get("rollback")     # noqa
+        # fmt: on
+
+        if config:
+            odoo_args.extend(["-c", config])
+        if log_level:
+            odoo_args.extend(["--log-level", log_level])
+        if logfile:
+            odoo_args.extend(["--logfile", logfile])
+        if addons_path:
+            odoo_args.extend(["--addons-path", addons_path])
+        if database:
+            odoo_args.extend(["-d", database])
+        if rollback:
+            self.rollback = rollback
         return odoo_args
 
     def load_odoo_config(self, ctx):

--- a/click_odoo/cli.py
+++ b/click_odoo/cli.py
@@ -35,6 +35,7 @@ class CommandWithOdooEnv(click.Command):
         self.rollback = None
         self.with_rollback = env_options.get("with_rollback", True)
         self.with_database = env_options.get("with_database", True)
+        self.with_addons_path = env_options.get("with_addons_path", False)
         self.database_must_exist = env_options.get("database_must_exist", True)
         self.database_required = self.with_database and env_options.get(
             "database_required", True
@@ -45,7 +46,7 @@ class CommandWithOdooEnv(click.Command):
 
         self.env_params = {
             options.config_opt,
-            options.addons_path_opt,
+            options.addons_path_opt if self.with_addons_path else None,
             options.db_opt if self.with_database else None,
             options.log_level_opt,
             options.logfile_opt,
@@ -70,10 +71,11 @@ class CommandWithOdooEnv(click.Command):
         if ctx.params.get("logfile"):
             odoo_args.extend(["--logfile", ctx.params["logfile"]])
         del ctx.params["logfile"]
+        # Conditionally present params
         if ctx.params.get("addons_path"):
             odoo_args.extend(["--addons-path", ctx.params["addons_path"]])
-        del ctx.params["addons_path"]
-        # Conditionally present params
+        if "addons_path" in ctx.params:
+            del ctx.params["addons_path"]
         if ctx.params.get("database"):
             odoo_args.extend(["-d", ctx.params["database"]])
         if "database" in ctx.params:
@@ -132,7 +134,10 @@ class CommandWithOdooEnv(click.Command):
             raise click.ClickException(str(e))
 
 
-@click.command(cls=CommandWithOdooEnv, env_options={"database_required": False})
+@click.command(
+    cls=CommandWithOdooEnv,
+    env_options={"database_required": False, "with_addons_path": True},
+)
 @options.interactive_opt
 @options.shell_interface_opt
 @options.script_arg

--- a/click_odoo/cli.py
+++ b/click_odoo/cli.py
@@ -27,9 +27,9 @@ def _db_exists(dbname):
 
 
 class CommandWithOdooEnv(click.Command):
-    def __init__(self, env_options=None, *args, **kwargs):
-        if not env_options:
-            env_options = {}
+    def __init__(self, env_options=None, default_overrides=None, *args, **kwargs):
+        env_options = env_options if env_options else {}
+        self.default_overrides = default_overrides if default_overrides else {}
         super(CommandWithOdooEnv, self).__init__(*args, **kwargs)
         self.database = None
         self.rollback = None
@@ -57,11 +57,9 @@ class CommandWithOdooEnv(click.Command):
 
     def _parse_env_args(self, ctx):
         def _get(flag):
-            result = ctx.params.get(flag) or self.config_settings.get(flag)
+            result = ctx.params.get(flag) or self.default_overrides.get(flag)
             if flag in ctx.params:
                 del ctx.params[flag]
-            if flag in self.config_settings:
-                del self.config_settings[flag]
             return result
 
         odoo_args = []

--- a/click_odoo/options.py
+++ b/click_odoo/options.py
@@ -1,0 +1,74 @@
+# Copyright 2018 ACSONE SA/NV (<http://acsone.eu>)
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
+import click
+
+# Wrapper options
+config_opt = click.Option(
+    ("--config", "-c"),
+    envvar=["ODOO_RC", "OPENERP_SERVER"],
+    type=click.Path(exists=True, dir_okay=False),
+    help="Specify the Odoo configuration file. Other "
+    "ways to provide it are with the ODOO_RC or "
+    "OPENERP_SERVER environment variables, "
+    "or ~/.odoorc (Odoo >= 10) "
+    "or ~/.openerp_serverrc.",
+)
+addons_path_opt = click.Option(
+    ("--addons-path",),
+    envvar=["ODOO_ADDONS_PATH"],
+    help="Specify the addons path. If present, this "
+    "parameter takes precedence over the addons path "
+    "provided in the Odoo configuration file.",
+)
+
+db_opt = click.Option(
+    ("--database", "-d"),
+    envvar=["PGDATABASE"],
+    help="Specify the database name. If present, this "
+    "parameter takes precedence over the database "
+    "provided in the Odoo configuration file.",
+)
+
+log_level_opt = click.Option(
+    ("--log-level",),
+    default="info",
+    show_default=True,
+    help="Specify the logging level. Accepted values depend "
+    "on the Odoo version, and include debug, info, "
+    "warn, error.",
+)
+
+logfile_opt = click.Option(
+    ("--logfile",), type=click.Path(dir_okay=False), help="Specify the log file."
+)
+
+rollback_opt = click.Option(
+    ("--rollback",),
+    is_flag=True,
+    help="Rollback the transaction even if the script "
+    "does not raise an exception. Note that if the "
+    "script itself commits, this option has no effect. "
+    "This is why it is not named dry run. This option "
+    "is implied when an interactive console is "
+    "started.",
+)
+
+# Main options
+interactive_opt = click.option(
+    "--interactive/--no-interactive",
+    "-i",
+    help="Inspect interactively after running the script.",
+)
+
+shell_interface_opt = click.option(
+    "--shell-interface",
+    help="Preferred shell interface for interactive mode. Accepted "
+    "values are ipython, ptpython, bpython, python. If not "
+    "provided they are tried in this order.",
+)
+
+script_arg = click.argument(
+    "script", required=False, type=click.Path(exists=True, dir_okay=False)
+)
+
+script_args_arg = click.argument("script-args", nargs=-1)

--- a/tests/test_click_odoo.py
+++ b/tests/test_click_odoo.py
@@ -271,11 +271,24 @@ def test_env_options_database_must_exist(odoodb):
         else:
             print("without env")
 
+    @click.command(cls=CommandWithOdooEnv)
+    def testcmd_must_exist(env):
+        pass
+
     # no database, must not exist, no env
     runner = CliRunner()
     result = runner.invoke(testcmd, ["-d", "dbthatdoesnotexist"])
     assert result.exit_code == 0
     assert "without env" in result.output
+
+    # no database, must exist, error
+    runner = CliRunner()
+    result = runner.invoke(testcmd_must_exist, ["-d", "dbthatdoesnotexist"])
+    assert result.exit_code != 0
+    assert (
+        "The provided database does not exists and this script requires"
+        in result.output
+    )
 
     # database exists, must not exist, env ok
     runner = CliRunner()
@@ -337,6 +350,7 @@ def test_write_defaulttx(odoodb):
     subprocess.check_call(cmd)
     _assert_testparam_present(odoodb, "testvalue")
 
+
 def test_write_rollback(odoodb):
     """ test click-odoo rollbacks itself """
     _cleanup_testparam(odoodb)
@@ -344,6 +358,7 @@ def test_write_rollback(odoodb):
     cmd = ["click-odoo", "--rollback", "-d", odoodb, "--", script]
     subprocess.check_call(cmd)
     _assert_testparam_absent(odoodb)
+
 
 def test_write_interactive_defaulttx(mocker, odoodb):
     """ test click-odoo rollbacks in interactive mode """

--- a/tests/test_click_odoo.py
+++ b/tests/test_click_odoo.py
@@ -360,6 +360,20 @@ def test_write_rollback(odoodb):
     _assert_testparam_absent(odoodb)
 
 
+def test_write_default_rollback(odoodb):
+    """ test click-odoo rollbacks itself via default_overrides """
+    _cleanup_testparam(odoodb)
+
+    @click.command(cls=CommandWithOdooEnv, default_overrides={"rollback": True})
+    def testcmd(env):
+        env = env  # noqa
+        env["ir.config_parameter"].set_param("testparam", "testvalue")
+
+    runner = CliRunner()
+    runner.invoke(testcmd, ["-d", odoodb])
+    _assert_testparam_absent(odoodb)
+
+
 def test_write_interactive_defaulttx(mocker, odoodb):
     """ test click-odoo rollbacks in interactive mode """
     mocker.patch.object(console.Shell, "python")

--- a/tests/test_click_odoo.py
+++ b/tests/test_click_odoo.py
@@ -311,7 +311,7 @@ def _assert_testparam_absent(dbname):
     conn.close()
 
 
-def test_write_commit(odoodb):
+def test_write_commit_in_script(odoodb):
     """ test commit in script """
     _cleanup_testparam(odoodb)
     script = os.path.join(here, "scripts", "script4.py")
@@ -320,7 +320,7 @@ def test_write_commit(odoodb):
     _assert_testparam_present(odoodb, "testvalue")
 
 
-def test_write_rollback(odoodb):
+def test_write_rollback_in_script(odoodb):
     """ test rollback in script """
     _cleanup_testparam(odoodb)
     script = os.path.join(here, "scripts", "script4.py")
@@ -337,6 +337,13 @@ def test_write_defaulttx(odoodb):
     subprocess.check_call(cmd)
     _assert_testparam_present(odoodb, "testvalue")
 
+def test_write_rollback(odoodb):
+    """ test click-odoo rollbacks itself """
+    _cleanup_testparam(odoodb)
+    script = os.path.join(here, "scripts", "script4.py")
+    cmd = ["click-odoo", "--rollback", "-d", odoodb, "--", script]
+    subprocess.check_call(cmd)
+    _assert_testparam_absent(odoodb)
 
 def test_write_interactive_defaulttx(mocker, odoodb):
     """ test click-odoo rollbacks in interactive mode """

--- a/tox.ini
+++ b/tox.ini
@@ -52,3 +52,8 @@ ODOO =
   11.0: 11.0
   12.0: 12.0
   master: master
+
+[pytest]
+filterwarnings =
+    once::DeprecationWarning
+    once::PendingDeprecationWarning


### PR DESCRIPTION
### Phase: Call for stable (rc2)
#### All xoe-labs downstream modules migrated and passing tests.

- Replaces https://github.com/acsone/click-odoo/pull/15
- For motivation and discussion, please refer / stick to #15
- If you want to use this versions:

```python
# setup.py
    ...
    setup_requires=["setuptools-scm"],
    install_requires=["click-odoo>=2.0.0.rc2"],
    dependency_links=[
      'git+https://github.com/xoe-labs/click-odoo.git@2.0.0#egg=click-odoo',
    ],
    license="LGPLv3+",
    ...
```

```ini
# tox.ini

[testenv]
...
deps =
  -rrequirements.txt
  git+https://github.com/xoe-labs/click-odoo.git@2.0.0#egg=click-odoo
  configparser>=3.5.0
  psycopg2
  pytest
  pytest-cov
  pytest-mock
...
[testenv:pre_commit]
deps =
  pre-commit
  git+https://github.com/xoe-labs/click-odoo.git@2.0.0#egg=click-odoo
commands =
  pre-commit run --all-files
```