### PR TITLE
[FIX] Properly compare version numbers

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
   rev: 18.9b0
   hooks:
   - id: black
-    language_version: python3.6
+    language_version: python3
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v1.4.0
   hooks:
@@ -13,19 +13,19 @@ repos:
   - id: debug-statements
   - id: flake8
     additional_dependencies: ["flake8-bugbear == 18.8.0"]
-    language_version: python3.6
+    language_version: python3
 - repo: https://github.com/asottile/pyupgrade
   rev: v1.6.1
   hooks:
   - id: pyupgrade
-    language_version: python3.6
+    language_version: python3
 - repo: https://github.com/asottile/seed-isort-config
   rev: v1.3.0
   hooks:
   - id: seed-isort-config
-    language_version: python3.6
+    language_version: python3
 - repo: https://github.com/pre-commit/mirrors-isort
   rev: v4.3.4
   hooks:
   - id: isort
-    language_version: python3.6
+    language_version: python3

--- a/click_odoo/env.py
+++ b/click_odoo/env.py
@@ -49,7 +49,9 @@ def OdooEnvironment(database, rollback=False, **kwargs):
                 else:
                     cr.commit()
         finally:
-            if odoo.release.version_info[0] < 10:
+            if odoo.tools.parse_version(
+                odoo.release.version
+            ) < odoo.tools.parse_version("10.0"):
                 odoo.modules.registry.RegistryManager.delete(database)
             else:
                 odoo.modules.registry.Registry.delete(database)

--- a/click_odoo/env_options.py
+++ b/click_odoo/env_options.py
@@ -112,7 +112,9 @@ class env_options(object):
         return value
 
     def _fix_odoo_logging(self):
-        if odoo.release.version_info[0] < 9:
+        if odoo.tools.parse_version(odoo.release.version) < odoo.tools.parse_version(
+            "9.0"
+        ):
             handlers = logging.getLogger().handlers
             if handlers and len(handlers) == 1:
                 handler = handlers[0]

--- a/tests/test_click_odoo.py
+++ b/tests/test_click_odoo.py
@@ -446,3 +446,27 @@ def test_env_options_addons_path():
     cmd = ["click-odoo", "--addons-path", addons_path, "--", script]
     r = subprocess.call(cmd)
     assert r == 0
+
+
+def test_parse_version():
+    versions = (
+        (
+            "4.2",
+            "4.2.3.4",
+            "5.0.0-alpha",
+            "5.0.0-rc1",
+            "5.0.0-rc1.1",
+            "5.0.0_rc2",
+            "5.0.0_rc3",
+            "5.0.0",
+            "12.0",
+            "saas~12.5",
+            "13.0",
+        ),
+        ("5.0.0-0_rc3", "5.0.0-1dev", "5.0.0-1"),
+    )
+    for sequence in versions:
+        smaller = "0"
+        for bigger in sequence:
+            assert odoo.tools.parse_version(smaller) < odoo.tools.parse_version(bigger)
+            smaller = bigger


### PR DESCRIPTION
To put you in context, I'm preparing a release for Odoo 13.0, but currently the closest thing we have is saas-12.5.

[In this version, `odoo.release.version_info[0]` is `"saas~12.5"`][1], which [produces errors][2] when using click-odoo because it's comparing an int to a str:

```
2019-09-11 12:43:49,398 1 ERROR ? click_odoo.env_options: exception
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/click_odoo/env_options.py", line 178, in _invoke
    self._configure_odoo(ctx)
  File "/usr/local/lib/python3.7/site-packages/click_odoo/env_options.py", line 155, in _configure_odoo
    self._fix_odoo_logging()
  File "/usr/local/lib/python3.7/site-packages/click_odoo/env_options.py", line 115, in _fix_odoo_logging
    if odoo.release.version_info[0] < 9:
TypeError: '<' not supported between instances of 'str' and 'int'
Error: '<' not supported between instances of 'str' and 'int'
```

I realized that not only click-odoo uses this system, but click-odoo-contrib also.

Reacting to Odoo version is a very important part of click-odoo scripting, so it seems better IMHO to supply a `click_odoo.parse_version()` function that, for now, just inherits Odoo's own method. In the future, if this method becomes inconsistent in Odoo, click-odoo would be the abstraction layer to preserve safety in click-odoo scripts. For now, it's consistent across all supported versions, so importing it should be enough.

[1]: https://github.com/odoo/odoo/blob/bc407fd18e68766bd49c772de7403d3d96dc3d47/odoo/release.py#L15
[2]: https://travis-ci.org/Tecnativa/doodba/jobs/583633629#L8708-L8717

@Tecnativa TT19268