### PR TITLE
[FIX] Force loading of server wide modules first

### DIFF
--- a/click_odoo/env_options.py
+++ b/click_odoo/env_options.py
@@ -162,6 +162,7 @@ class env_options(object):
         odoo.tools.config.parse_config(odoo_args)
         self._fix_odoo_logging()
         self._fix_disable_wsgi_module_handlers()
+        odoo.service.server.load_server_wide_modules()
         odoo.cli.server.report_configuration()
 
     def _db_exists(self, dbname):


### PR DESCRIPTION
Without this change even if an addon is declared as server wide module, the import is not done before others addons.
With this change we solve a problem with addons depending of base_sparse_field. base_sparse_field, patch the odoo.fields module to add the Serialized field. When an addon depends on base_sparse_field, the common way to declare a Serialized field is to write:
```python
from odoo import fields
...
    my_serialized = fields.Serialized()
```
Unfortunately we observe in some cases that even if the addon is declared as a dependency of the addon using this kind of field, the code of the base_sparse_field is not yet imported when the addon is added into the python path and an AttributeError is raised: AttributeError: module 'odoo.fields' has no attribute 'Serialized'

A way to fix this issue at server startup is to delare base_spare_field as server_wide_addon. Unfortunately, this parameter was ignored by click-doo before this change.

Observed with Odoo 13.0