### PR TITLE
Readme. Remove incorrect code example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,10 +46,6 @@ or::
 
   click-odoo -d dbname --log-level=error ./list-users.py
 
-or::
-
-  ./list-users.py -d dbname --log-level=error
-
 The other technique to create scripts looks like this. Assuming
 the following script named ``list-users2.py``.
 


### PR DESCRIPTION
This code example doesn't work. It's for old script with shebang `#!/bin/env odoo-script`