### PR TITLE
Load server wide modules in environment

### DIFF
--- a/click_odoo/env.py
+++ b/click_odoo/env.py
@@ -13,6 +13,7 @@ _logger = logging.getLogger(__name__)
 @contextmanager
 def OdooEnvironment(database, rollback=False, **kwargs):
     with environment_manage():
+        odoo.service.server.load_server_wide_modules()
         registry = odoo.modules.registry.Registry(database)
         try:
             with registry.cursor() as cr:


### PR DESCRIPTION
Odoo loads server wide modules before doing anything else (see https://github.com/odoo/odoo/blob/16.0/odoo/service/server.py#L1356), not doing it here can break modules that expect server wide modules to be loaded.