### PR TITLE
odoo.registry deprecated

### DIFF
--- a/click_odoo/env.py
+++ b/click_odoo/env.py
@@ -12,7 +12,7 @@ _logger = logging.getLogger(__name__)
 @contextmanager
 def OdooEnvironment(database, rollback=False, **kwargs):
     with environment_manage():
-        registry = odoo.registry(database)
+        registry = odoo.modules.registry.Registry(database)
         try:
             with registry.cursor() as cr:
                 uid = odoo.SUPERUSER_ID

--- a/newsfragments/60.feature
+++ b/newsfragments/60.feature
@@ -1,0 +1,1 @@
+Use ``odoo.modules.registry.Registry()`` instead of the now deprecated `odoo.registry()`.


### PR DESCRIPTION
As of Odoo 18, odoo.registry is deprecated.
See https://github.com/odoo/odoo/commit/447b35548dc5d6526885eb4f2397d7a0dca22521