### PR TITLE
Source python startup file before launching repl

### DIFF
--- a/click_odoo/console.py
+++ b/click_odoo/console.py
@@ -13,6 +13,14 @@ class Shell:
 
     @classmethod
     def python(cls, local_vars):
+        if os.getenv("PYTHONSTARTUP"):
+            # If PYTHONSTARTUP is defined, run it.
+            startup_file = os.getenv("PYTHONSTARTUP")
+            if os.path.isfile(startup_file):
+                with open(startup_file) as f:
+                    startup = f.read()
+                exec(startup, local_vars)
+
         console = code.InteractiveConsole(locals=local_vars)
         import readline
         import rlcompleter  # noqa

--- a/newsfragments/74.feature
+++ b/newsfragments/74.feature
@@ -1,0 +1,1 @@
+Honor PYTHONSTARTUP environment variable the same way the python repl does.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,3 +9,8 @@ build-backend = "setuptools.build_meta"
     issue_format = "`#{issue} <https://github.com/acsone/click-odoo/issues/{issue}>`_"
     directory = "newsfragments/"
     filename = "CHANGES.rst"
+
+[dependency-groups]
+dev = [
+    "towncrier>=25.8.0",
+]


### PR DESCRIPTION
It would be nice to have the same repl as python if the [PYTHONSTARTUP](https://docs.python.org/3/using/cmdline.html#envvar-PYTHONSTARTUP) environment variable is defined.