### PR TITLE
Import odoo.cli when used

### DIFF
--- a/click_odoo/env_options.py
+++ b/click_odoo/env_options.py
@@ -146,7 +146,10 @@ class env_options:
             odoo.tools.config.parse_config(odoo_args, setup_logging=True)
         else:
             odoo.tools.config.parse_config(odoo_args)
-        odoo.cli.server.report_configuration()
+
+        from odoo.cli.server import report_configuration
+
+        report_configuration()
 
     def _db_exists(self, dbname):
         conn = odoo.sql_db.db_connect("postgres")


### PR DESCRIPTION
The package is not imported anymore when importing `odoo`. Force the import at this point.