### PR TITLE
[FIX] Allow to execute a valid sys.path entry.

### DIFF
--- a/click_odoo/cli.py
+++ b/click_odoo/cli.py
@@ -35,7 +35,7 @@ _logger = logging.getLogger(__name__)
     "values are ipython, ptpython, bpython, python. If not "
     "provided they are tried in this order.",
 )
-@click.argument("script", required=False, type=click.Path(exists=True, dir_okay=False))
+@click.argument("script", required=False, type=click.Path(exists=True))
 @click.argument("script-args", nargs=-1)
 def main(env, interactive, shell_interface, script, script_args):
     global_vars = {"env": env}

--- a/newsfragments/73.bugfix
+++ b/newsfragments/73.bugfix
@@ -1,0 +1,3 @@
+Allow to execute a valid sys.path entry.
+click-odoo is using runpy.run_path(path_name, ...) function.
+path_name can be a file, but can be also a folder, in the case we want to import a syst.path entry, containing a __main__.py file.

--- a/newsfragments/73.bugfix
+++ b/newsfragments/73.bugfix
@@ -1,3 +1,1 @@
-Allow to execute a valid sys.path entry.
-click-odoo is using runpy.run_path(path_name, ...) function.
-path_name can be a file, but can be also a folder, in the case we want to import a syst.path entry, containing a __main__.py file.
+Accept a directory containing a ``__main__.py`` as script.


### PR DESCRIPTION
Hi. First, thanks for this great tool I began to use some weeks ago.

**About that fix:**
click-odoo is using ``runpy.run_path(path_name, ...)`` function. ``path_name`` can be a file, but can be also a folder, in the case we want to import a syst.path entry, containing a ``__main__.py`` file.

this patch allow such call.

Ref : https://docs.python.org/3/library/runpy.html#runpy.run_path

Hi. this is a quite trivial patch. This is the first time I contribute on click-odoo, let me know if extra things are required. 